### PR TITLE
change null prob threshold

### DIFF
--- a/pretrained_bert_base_squad.jsonnet
+++ b/pretrained_bert_base_squad.jsonnet
@@ -16,10 +16,10 @@
     "pretrained_archive_path": "https://s3-us-west-2.amazonaws.com/pradeepd-bert-qa-models/bert-base/bert_base_archive.tar.gz",
     // for BERT large
     // "pretrained_archive_path": "https://s3-us-west-2.amazonaws.com/pradeepd-bert-qa-models/bert-large/bert_large_archive.tar.gz",
-    // BERT base threshold
-    "null_score_difference_threshold": -1.75 
-    // BERT large threshold
-    // "null_score_difference_threshold": -1.98477 
+    // BERT base threshold; dev tuned number of -1.7497849464416504
+    "null_score_difference_threshold": 0.0 
+    // BERT large threshold, dev tuned number is -1.9847722053527832
+    // "null_score_difference_threshold": 0.0 
   },
   "iterator": {
     "type": "basic",

--- a/pretrained_bert_large_squad.jsonnet
+++ b/pretrained_bert_large_squad.jsonnet
@@ -18,9 +18,9 @@
     // for BERT large
     "pretrained_archive_path": "https://s3-us-west-2.amazonaws.com/pradeepd-bert-qa-models/bert-large/bert_large_archive.tar.gz",
     // BERT base threshold
-    //"null_score_difference_threshold": -1.75 
-    // BERT large threshold
-    "null_score_difference_threshold": -1.98477 
+    //"null_score_difference_threshold": 0.0 
+    // BERT large threshold; dev tuned number is -1.9847722053527832
+    "null_score_difference_threshold": 0.0 
   },
   "iterator": {
     "type": "basic",


### PR DESCRIPTION
`null_score_difference_threshold` is the used to determine when to predict "NO ANSWER". If the difference between a the score assigned to null, and the one assigned to the best non-null option os greater than this value, "NO ANSWER" is predicted. Looks like a [recommended way](https://github.com/google-research/bert#squad-20) of doing this is to tune it on the dev set. Earlier I used the tuned values, but it feels like the QA system is predicting "NO ANSWER" way too many times. I'm resetting this to 0 to treat "NO ANSWER" like any other span.